### PR TITLE
mingw compatibility

### DIFF
--- a/src/os_rand.c
+++ b/src/os_rand.c
@@ -5,6 +5,13 @@
 # include <stdio.h>
 # include <unistd.h>
 #elif defined(WIN32) || defined(_WIN32)
+
+//bypass crtdefs.h ssize_t typedef
+#ifndef _SSIZE_T_DEFINED
+#define _SSIZE_T_DEFINED
+typedef long long ssize_t;
+#endif /* _SSIZE_T_DEFINED */
+
 # include <windows.h>
 # include <stdbool.h>
 # include <stdio.h>
@@ -30,7 +37,6 @@ extern "C"
 BOOLEAN NTAPI RtlGenRandom(PVOID RandomBuffer, ULONG RandomBufferLength);
 # pragma comment(lib, "advapi32.lib")
 
-typedef long long ssize_t;
 #endif
 
 void os_randominit(const uint8_t* seed, size_t seed_size)


### PR DESCRIPTION
New versions of mingw include the typedef of ssize_t
But they include a 16bit int for ssize_t and not a 64bit long long int

So _SSIZE_T_DEFINED is defined to set the size of ssize_t before
the header files set them and check if _SSIZE_T_DEFINED is defined or not