### PR TITLE
vgp: add public-facing header for VGP's API

### DIFF
--- a/include/vgp/vgp.hpp
+++ b/include/vgp/vgp.hpp
@@ -1,0 +1,19 @@
+// Copyright (c) 2021 Duality Blockchain Solutions LLC
+// See LICENSE.md file for license, copying and use information.
+
+#ifndef VGP_HEADER_H__
+#define VGP_HEADER_H__
+
+#include "../encryption.h"
+
+namespace VGP {
+bool Encrypt(const vCharVector& vchPubKeys, const CharVector& vchData, CharVector& vchCipherText, std::string& strErrorMessage) {
+ 	return EncryptBDAPData(vchPubKeys, vchData, vchCipherText, strErrorMessage);
+}
+
+bool Decrypt(const CharVector& vchPrivKeySeed, const CharVector& vchCipherText, CharVector& vchData, std::string& strErrorMessage) {
+	return DecryptBDAPData(vchPrivKeySeed, vchCipherText, vchData, strErrorMessage);
+}
+}
+
+#endif // VGP_HEADER_H__


### PR DESCRIPTION
Currently the includes in Dynamic are `#include <encryption.h>` which is relatively ambiguous.

`#include <vgp/vgp.hpp>` makes it clear that it's a libvgp include and also limits the public-facing API to the VGP namespace, allowing for easier identification while reading.